### PR TITLE
feat!: deal with `path_display` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,19 @@ Filepath for the binary `ghq`.
 
 Transform the result paths into relative ones with this value as the base dir.
 
-Default value: `vim.fn.getcwd()`
+Default value: `vim.uv.cwd()`
 
-#### `tail_path`
+#### `tail_path` (deprecated)
+
+***This is deprecated. Use `path_display` (`:h telescope.defaults.path_display`).***
 
 Show only basename of the path.
 
 Default value: `false`
 
-#### `shorten_path`
+#### `shorten_path` (deprecated)
+
+***This is deprecated. Use `path_display` (`:h telescope.defaults.path_display`).***
 
 Call `pathshorten()` for each path.
 

--- a/lua/telescope/_extensions/ghq_builtin.lua
+++ b/lua/telescope/_extensions/ghq_builtin.lua
@@ -88,7 +88,8 @@ end
 
 M.list = function(opts)
   opts = opts or {}
-  opts.bin = opts.bin and vim.fn.expand(opts.bin) or "ghq"
+  opts.bin = opts.bin and vim.fn.expand(opts.bin) --[[@as string]]
+    or "ghq"
   opts.cwd = utils.get_lazy_default(opts.cwd, uv.cwd)
   opts.entry_maker = utils.get_lazy_default(opts.entry_maker, gen_from_ghq, opts)
 

--- a/lua/telescope/_extensions/ghq_builtin.lua
+++ b/lua/telescope/_extensions/ghq_builtin.lua
@@ -73,7 +73,7 @@ local function gen_from_ghq(opts)
       return path
     end)(entry.path)
 
-    return displayer { dir }
+    return displayer { utils.transform_path(opts, dir) }
   end
 
   return function(line)


### PR DESCRIPTION
Now it considers default settings of telescope.nvim itself.